### PR TITLE
Add simple story engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# codex_projects
+# Story Engine
+
+This project is a minimal terminal-based story engine that demonstrates a simple
+pipeline of parsing natural language, generating a character response and storing
+relationship memory.
+
+## Files
+
+- `parser.py` – converts a line of natural language into a structured dictionary
+  containing `intent`, `tone`, `emotion` and `target`.
+- `responder.py` – produces a character response based on a JSON profile and the
+  parsed input.
+- `memory.py` – manages relationship values that persist between interactions.
+- `main.py` – command line interface that ties everything together and saves a
+  sample character profile if one does not exist.
+
+## Usage
+
+Run the application with:
+
+```bash
+python main.py
+```
+
+Type text at the prompt and observe the parser output, the generated response
+and memory updates saved to `memory.json`.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,54 @@
+"""Command-line interface tying together the parser, responder and memory."""
+import json
+from pathlib import Path
+
+import parser as nlp_parser
+import responder
+import memory
+
+PROFILE_FILE = 'character.json'
+
+
+def ensure_sample_profile() -> None:
+    """Create a simple sample profile if none exists."""
+    if not Path(PROFILE_FILE).exists():
+        sample = {
+            "name": "Alex",
+            "traits": ["friendly", "curious"],
+        }
+        with open(PROFILE_FILE, 'w') as f:
+            json.dump(sample, f, indent=2)
+
+
+def main() -> None:
+    ensure_sample_profile()
+    profile = responder.load_profile(PROFILE_FILE)
+    mem = memory.load_memory()
+
+    print("Enter text (type 'quit' to exit):")
+    while True:
+        try:
+            line = input('> ').strip()
+        except EOFError:
+            break
+        if line.lower() in {'quit', 'exit'}:
+            break
+        parsed = nlp_parser.parse_input(line)
+        print('Parsed:', parsed)
+        response = responder.respond(profile, parsed)
+        print('Response:', response)
+
+        # Update memory as simple example
+        if parsed['intent'] == 'greet':
+            memory.update_relationship(mem, profile['name'], 1)
+        elif parsed['intent'] == 'attack':
+            memory.update_relationship(mem, profile['name'], -1)
+
+        memory.save_memory(mem)
+        print('Memory:', json.dumps(mem, indent=2))
+
+    print('Goodbye!')
+
+
+if __name__ == '__main__':
+    main()

--- a/memory.py
+++ b/memory.py
@@ -1,0 +1,26 @@
+"""Memory system for tracking character relationships."""
+import json
+from typing import Dict
+
+MEMORY_FILE = 'memory.json'
+
+
+def load_memory() -> Dict:
+    """Load memory from the JSON file."""
+    try:
+        with open(MEMORY_FILE, 'r') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {"relationships": {}}
+
+
+def save_memory(memory: Dict) -> None:
+    """Persist memory to disk."""
+    with open(MEMORY_FILE, 'w') as f:
+        json.dump(memory, f, indent=2)
+
+
+def update_relationship(memory: Dict, character: str, delta: int) -> None:
+    """Update relationship value with a delta."""
+    relationships = memory.setdefault("relationships", {})
+    relationships[character] = relationships.get(character, 0) + delta

--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,53 @@
+"""Simple natural language parser for the story engine."""
+from typing import Dict
+
+
+def parse_input(text: str) -> Dict[str, str]:
+    """Parse raw text and return structured data.
+
+    Args:
+        text: Raw user input.
+
+    Returns:
+        Dictionary with keys: intent, tone, emotion, target.
+    """
+    lowered = text.lower()
+    data = {
+        "intent": "talk",
+        "tone": "neutral",
+        "emotion": "neutral",
+        "target": "none",
+    }
+
+    # Determine intent based on simple keywords
+    if any(word in lowered for word in ["attack", "hit", "punch"]):
+        data["intent"] = "attack"
+    elif any(word in lowered for word in ["hello", "hi", "greet"]):
+        data["intent"] = "greet"
+    elif "help" in lowered:
+        data["intent"] = "help"
+
+    # Determine tone
+    if lowered.endswith("?"):
+        data["tone"] = "question"
+    elif any(word in lowered for word in ["please", "kindly"]):
+        data["tone"] = "polite"
+
+    # Determine emotion
+    if any(word in lowered for word in ["love", "like"]):
+        data["emotion"] = "positive"
+    elif any(word in lowered for word in ["hate", "anger", "angry"]):
+        data["emotion"] = "negative"
+
+    # Target extraction: look for words after '@'
+    if "@" in text:
+        try:
+            at_index = text.index("@")
+            target = text[at_index + 1 :].split()[0]
+            data["target"] = target
+        except Exception:
+            pass
+    elif "you" in lowered:
+        data["target"] = "you"
+
+    return data

--- a/responder.py
+++ b/responder.py
@@ -1,0 +1,32 @@
+"""Generate character responses based on parsed input and character profile."""
+import json
+from typing import Dict
+
+
+def load_profile(path: str) -> Dict:
+    """Load a character profile from a JSON file."""
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def respond(profile: Dict, parsed: Dict[str, str]) -> str:
+    """Return a textual response based on the profile and parsed input."""
+    name = profile.get('name', 'Someone')
+    intent = parsed.get('intent')
+    tone = parsed.get('tone')
+
+    if intent == 'greet':
+        response = f"{name} smiles and greets you back."
+    elif intent == 'attack':
+        response = f"{name} dodges defensively, looking startled."
+    elif intent == 'help':
+        response = f"{name} nods and offers assistance."
+    else:
+        response = f"{name} listens." 
+
+    if tone == 'question':
+        response += " They seem thoughtful about your question."
+    elif tone == 'polite':
+        response += " They appreciate your manners."
+
+    return response


### PR DESCRIPTION
## Summary
- create parser, responder, memory, and main modules for an interactive story engine
- add simple README explaining usage

## Testing
- `python -m py_compile parser.py responder.py memory.py main.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_687e7f1fa1dc83289ddbb3fd41e36b9a