### PR TITLE
Initialize project_mirror structure with placeholder modules

### DIFF
--- a/project_mirror/__init__.py
+++ b/project_mirror/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for the project_mirror system."""

--- a/project_mirror/api/__init__.py
+++ b/project_mirror/api/__init__.py
@@ -1,0 +1,1 @@
+"""API package for LLM wrappers and simulation request routing."""

--- a/project_mirror/api/gpt_wrapper.py
+++ b/project_mirror/api/gpt_wrapper.py
@@ -1,0 +1,5 @@
+"""Wrapper around GPT or other LLM API calls, exposing interfaces for simulation modules."""
+
+# Placeholder for LLM API interaction logic
+
+

--- a/project_mirror/data/__init__.py
+++ b/project_mirror/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data package for local database or vector store configuration."""

--- a/project_mirror/frontend/__init__.py
+++ b/project_mirror/frontend/__init__.py
@@ -1,0 +1,1 @@
+"""Frontend interfaces such as a CLI or Streamlit app."""

--- a/project_mirror/memory/__init__.py
+++ b/project_mirror/memory/__init__.py
@@ -1,0 +1,1 @@
+"""Memory package for persistent user data and feedback loops."""

--- a/project_mirror/memory/profile_manager.py
+++ b/project_mirror/memory/profile_manager.py
@@ -1,0 +1,5 @@
+"""Manages user profile persistence, behavior tracking, and emotional feedback loops."""
+
+# Placeholder for user profile management logic
+
+

--- a/project_mirror/simulation/__init__.py
+++ b/project_mirror/simulation/__init__.py
@@ -1,0 +1,1 @@
+"""Simulation package for running life decision simulations."""

--- a/project_mirror/simulation/decision_engine.py
+++ b/project_mirror/simulation/decision_engine.py
@@ -1,0 +1,5 @@
+"""Core engine for simulating life decisions based on user profiles and LLM responses."""
+
+# Placeholder for decision simulation logic
+
+


### PR DESCRIPTION
## Summary
- scaffold `project_mirror` package with simulation, memory, api, frontend, and data modules
- add placeholder modules `decision_engine.py`, `profile_manager.py`, and `gpt_wrapper.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688cd108bb8c8328b0ef8deb2b078dff